### PR TITLE
Strange wording in README (the GMP)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -46,7 +46,7 @@ programming language.
    - Untagged and unboxed native integers, reals, and words.
    - Unboxed native arrays.
    - Multiple garbage collection strategies.
-   - Fast arbitrary-precision arithmetic based on the GMP.
+   - Fast arbitrary-precision arithmetic based on the GMP library.
 
  * Tools.
 


### PR DESCRIPTION
Just noticed this. The official page for GMP uses it without an article, or as "the GMP [Bignum/Arithmetical] library". Verbosity makes it easier to search for people who don't know